### PR TITLE
Typo in Vector names

### DIFF
--- a/Worksheets/Worksheet1_Notebook.ipynb
+++ b/Worksheets/Worksheet1_Notebook.ipynb
@@ -81,7 +81,7 @@
       "\\begin{align}\n",
       "  | {\\bf v}_{1} |_1 &= 1 + 3 + 1 = 5, \\\\\n",
       "  | {\\bf v}_{2} |_1 &= 1 + 2 = 3, \\\\\n",
-      "  | {\\bf v}_{2} |_1 &= 1 + 6 + 3 + 1 = 11.\n",
+      "  | {\\bf v}_{3} |_1 &= 1 + 6 + 3 + 1 = 11.\n",
       "\\end{align}\n",
       "\n",
       "The 2-norm is the square root of the sum of the squares, so\n",
@@ -89,7 +89,7 @@
       "\\begin{align}\n",
       "  | {\\bf v}_{1} |_2 &= \\sqrt{1^2 + 3^2 + 1^2} = \\sqrt{11} \\approx 3.3166, \\\\\n",
       "  | {\\bf v}_{2} |_2 &= \\sqrt{1^2 + 3^2} = \\sqrt{10} \\approx 2.2361, \\\\\n",
-      "  | {\\bf v}_{2} |_2 &= \\sqrt{1^2 + 6^2 + 3^2 + 1^2} = \\sqrt{47} \\approx 6.8557.\n",
+      "  | {\\bf v}_{3} |_2 &= \\sqrt{1^2 + 6^2 + 3^2 + 1^2} = \\sqrt{47} \\approx 6.8557.\n",
       "\\end{align}\n",
       "\n",
       "The $\\infty$-norm is the maximum absolute value, so \n",
@@ -97,7 +97,7 @@
       "\\begin{align}\n",
       "  | {\\bf v}_{1} |_{\\infty} &= 3, \\\\\n",
       "  | {\\bf v}_{2} |_{\\infty} &= 2, \\\\\n",
-      "  | {\\bf v}_{2} |_{\\infty} &= 6.\n",
+      "  | {\\bf v}_{3} |_{\\infty} &= 6.\n",
       "\\end{align}\n"
      ]
     },


### PR DESCRIPTION
wk1, ipython notebook, Answer 1 - vector 3 referred to as vector 2
